### PR TITLE
:recycle: C++20 Modules & Async Context Implementation

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,11 @@
+BasedOnStyle: Mozilla
+Language: Cpp
+UseTab: Never
+AlwaysBreakAfterReturnType: None
+AlwaysBreakAfterDefinitionReturnType: None
+AllowShortFunctionsOnASingleLine: None
+FixNamespaceComments: true
+SpacesBeforeTrailingComments: 2
+ColumnLimit: 80
+QualifierAlignment: Right
+InsertNewlineAtEOF: true

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,21 @@
+Checks: "-header-filter=.*,readability-identifier-naming,modernize-*,performance-*,bugprone-*,-modernize-use-trailing-return-type,-checks=-*"
+WarningsAsErrors: "*"
+UseColor: true
+CheckOptions:
+  - { key: readability-identifier-naming.NamespaceCase, value: lower_case }
+  - { key: readability-identifier-naming.ClassCase, value: lower_case }
+  - { key: readability-identifier-naming.VariableCase, value: lower_case }
+  - { key: readability-identifier-naming.PrivateMemberCase, value: lower_case }
+  - { key: readability-identifier-naming.PrivateMemberPrefix, value: m_ }
+  - { key: readability-identifier-naming.StructCase, value: lower_case }
+  - { key: readability-identifier-naming.ParameterCasePrefix, value: p_ }
+  - { key: readability-identifier-naming.ParameterCase, value: lower_case }
+  - { key: readability-identifier-naming.FunctionCase, value: lower_case }
+  - { key: readability-identifier-naming.MacroDefinition, value: UPPER_CASE }
+  - { key: readability-identifier-naming.EnumConstantCase, value: lower_case }
+  - { key: readability-identifier-naming.ConstantMemberCase, value: lower_case }
+  - { key: readability-identifier-naming.ClassConstantCase, value: lower_case }
+  - { key: readability-identifier-naming.GlobalConstantCase, value: lower_case }
+  - { key: readability-identifier-naming.LocalConstantCase, value: lower_case }
+  - { key: readability-identifier-naming.StaticConstantCase, value: lower_case }
+  - { key: readability-identifier-naming.ConstantCase, value: lower_case }

--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,4 @@
+CompileFlags:
+  CompilationDatabase: .
+  BuiltinHeaders: QueryDriver
+

--- a/.cmake-format
+++ b/.cmake-format
@@ -1,0 +1,4 @@
+format:
+  tab_size: 2
+  line_width: 80
+  dangle_parens: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,66 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# IDEs
+.vscode/
+archives/
+
+# GDB
+.gdb_history
+
+# Artifacts
+build/
+tools/
+
+# lint artifacts
+compile_commands.json
+.cache/
+
+# OS files
+.DS_Store
+
+# Conan Files
+graph_info.json
+conaninfo.txt
+conan.lock
+conanbuildinfo.txt
+
+# CMake
+CMakeUserPresets.json
+
+# Python Virtual
+.venv/
+.env/
+
+# Doxygen
+*/doxygen/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,83 @@
+# Copyright 2024 - 2025 Khalil Estell and the libhal contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.28)
+
+# Generate compile commands for anyone using our libraries.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+project(async_context LANGUAGES CXX)
+
+# ==============================================================================
+# Library
+# ==============================================================================
+
+add_library(async_context STATIC)
+target_compile_features(async_context PUBLIC cxx_std_23)
+target_sources(async_context PUBLIC
+    FILE_SET CXX_MODULES
+    TYPE CXX_MODULES
+
+    FILES
+    modules/async_context.cppm
+)
+
+install(
+    TARGETS async_context
+    EXPORT async_context_targets
+    FILE_SET CXX_MODULES DESTINATION "."
+    LIBRARY DESTINATION "lib"
+    ARCHIVE DESTINATION "lib"
+    CXX_MODULES_BMI DESTINATION "bmi"
+)
+
+install(
+    EXPORT async_context_targets
+    FILE "libasync_context-config.cmake"
+    NAMESPACE libasync_context::
+    DESTINATION "lib/cmake"
+    CXX_MODULES_DIRECTORY "cxx-modules"
+)
+
+# ==============================================================================
+# Unit testing
+# ==============================================================================
+
+find_package(ut REQUIRED)
+
+add_executable(async_unit_test)
+
+# Add module files
+target_sources(async_unit_test
+  PRIVATE
+      tests/main.test.cpp
+      tests/async.test.cpp
+)
+
+target_compile_features(async_unit_test PUBLIC cxx_std_23)
+target_link_libraries(async_unit_test PRIVATE async_context boost-ext-ut::ut)
+
+if(CMAKE_CROSSCOMPILING)
+    message(STATUS "Cross compiling, skipping unit test execution")
+else()
+    message(STATUS "Executing unit tests!")
+    add_custom_target(run_tests ALL DEPENDS async_unit_test COMMAND async_unit_test)
+endif()
+
+# Always run this custom target by making it depend on ALL
+add_custom_target(copy_compile_commands ALL
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    ${CMAKE_BINARY_DIR}/compile_commands.json
+    ${CMAKE_SOURCE_DIR}/compile_commands.json
+    DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json)

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,123 @@
+#!/usr/bin/python
+#
+# Copyright 2024 - 2025 Khalil Estell and the libhal contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout, CMakeToolchain, CMakeDeps
+from conan.tools.files import copy
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from pathlib import Path
+
+
+required_conan_version = ">=2.2.0"
+
+
+class async_context_conan(ConanFile):
+    name = "async_context"
+    license = "Apache-2.0"
+    url = "https://github.com/libhal/async_context"
+    homepage = "https://github.com/libhal/async_context"
+    description = ("Implementation of C++20 coroutines targeting embedded system by eliminating the usage of the global heap and providing a 'context' which contains a coroutine stack frame and other useful utilities for scheduling.")
+    topics = ("async", "coroutines", "stack", "scheduling", "scheduler")
+    settings = "compiler", "build_type", "os", "arch"
+    exports_sources = "include/*", "tests/*", "CMakeLists.txt", "LICENSE"
+    package_type = "static-library"
+    shared = False
+
+    @property
+    def _min_cppstd(self):
+        return "23"
+
+    @property
+    def _compilers_minimum_version(self):
+        # We may reduce these in the future.
+        return {
+            "gcc": ("14", "GCC 14+ required for async_context"),
+            "clang": (
+                "19",
+                "Clang 19+ required for async_context"
+            ),
+            "apple-clang": (
+                "19.0.0",
+                "Apple Clang 19+ for async_context"
+            ),
+            "msvc": (
+                "193.4",
+                "MSVC 14.34+ (Visual Studio 17.4+) for async_context"
+            )
+        }
+
+    def _validate_compiler_version(self):
+        """Validate compiler version against minimum requirements"""
+        compiler = str(self.settings.compiler)
+        version = str(self.settings.compiler.version)
+
+        # Map Visual Studio to msvc for consistency
+        compiler_key = "msvc" if compiler == "Visual Studio" else compiler
+
+        min_versions = self._compilers_minimum_version
+        if compiler_key not in min_versions:
+            raise ConanInvalidConfiguration(
+                f"Compiler {compiler} is not supported for C++20 modules")
+
+        min_version, error_msg = min_versions[compiler_key]
+        if version < min_version:
+            raise ConanInvalidConfiguration(error_msg)
+
+    def validate(self):
+        if self.settings.get_safe("compiler.cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+
+        self._validate_compiler_version()
+
+    def build_requirements(self):
+        self.tool_requires("cmake/4.1.1")
+        self.tool_requires("ninja/1.13.1")
+        self.test_requires("boost-ext-ut/2.3.1")
+
+    def requirements(self):
+        pass
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generator = "Ninja"
+        tc.cache_variables["CMAKE_CXX_SCAN_FOR_MODULES"] = True
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+        copy(self, "LICENSE",
+             dst=Path(self.package_folder) / "licenses",
+             src=self.source_folder)
+
+    def package_info(self):
+        # DISABLE Conan's config file generation
+        self.cpp_info.set_property("cmake_find_mode", "none")
+        # Tell CMake to include this directory in its search path
+        self.cpp_info.builddirs.append("lib/cmake")

--- a/tests/async.test.cpp
+++ b/tests/async.test.cpp
@@ -1,0 +1,28 @@
+// Copyright 2024 - 2025 Khalil Estell and the libhal contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <boost/ut.hpp>
+
+import async_context;
+
+namespace async {
+boost::ut::suite<"async::context"> adc24_test = []() {
+  using namespace boost::ut;
+  "<TBD>"_test = []() {
+    // Setup
+    // Exercise
+    // Verify
+  };
+};
+}

--- a/tests/main.test.cpp
+++ b/tests/main.test.cpp
@@ -1,0 +1,25 @@
+// Copyright 2024 - 2025 Khalil Estell and the libhal contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// export module libahl_unit_tests;
+
+namespace hal {
+// Extern position dependant test go here. Refrain from using this whenever
+// possible.
+}  // namespace hal
+
+int main()
+{
+  // Position dependent test go below:
+}


### PR DESCRIPTION
- **Introduce C++20 modules support** with `async_context.cppm` as the module implementation
- **Add configuration files** for code formatting and linting: `.clang-format`, `.clang-tidy`, `.clangd`, and `.cmake-format`
- **Set up CMake build system** with `CMakeLists.txt` for building the library as a static module
- **Create Conan package configuration** in `conanfile.py` for cross-platform builds and dependency management
- **Include boilerplate unit tests setup**
- **Add .gitignore** to exclude build artifacts, IDE files, and temporary files
- **Update namespace and class names** from `hal::v5::async_*` to `async::*` for cleaner API
- **Changes time duration types** from `hal::time_duration` to `std::chrono::nanoseconds`
- **Introduces module-based structure** with proper export and import declarations
- **Improve error handling** by making `bad_coroutine_alloc` inherit bad_alloc.