### PR TITLE
Add scheduler allocator interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,15 @@ target_sources(async_context PUBLIC
     FILES
     modules/async_context.cppm
 )
+target_compile_options(async_context PRIVATE
+    -g
+    -Werror
+    -Wno-unused-command-line-argument
+    -Wall
+    -Wextra
+    -Wshadow
+    -fexceptions
+    -fno-rtti)
 
 install(
     TARGETS async_context
@@ -73,7 +82,15 @@ else()
     )
 
     target_compile_features(async_unit_test PUBLIC cxx_std_23)
-    target_compile_options(async_unit_test PRIVATE -g)
+    target_compile_options(async_unit_test PRIVATE
+        -g
+        -Werror
+        -Wno-unused-command-line-argument
+        -Wall
+        -Wextra
+        -Wshadow
+        -fexceptions
+        -fno-rtti)
     target_link_libraries(async_unit_test PRIVATE async_context Boost::ut)
 
     add_custom_target(run_tests ALL DEPENDS async_unit_test COMMAND async_unit_test)

--- a/conanfile.py
+++ b/conanfile.py
@@ -89,7 +89,7 @@ class async_context_conan(ConanFile):
         self.test_requires("boost-ext-ut/2.3.1")
 
     def requirements(self):
-        self.requires("strong_ptr/0.0.2")
+        self.requires("strong_ptr/0.1.2")
 
     def layout(self):
         cmake_layout(self)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -36,6 +36,15 @@ target_sources(${PROJECT_NAME} PUBLIC
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_23)
 target_link_libraries(${PROJECT_NAME} PRIVATE async_context)
 
+target_compile_options(${PROJECT_NAME} PRIVATE
+    -g
+    -Werror
+    -Wno-unused-command-line-argument
+    -Wall
+    -Wextra
+    -Wshadow
+    -fexceptions
+    -fno-rtti)
 # Always run this custom target by making it depend on ALL
 add_custom_target(copy_compile_commands ALL
     COMMAND ${CMAKE_COMMAND} -E copy_if_different


### PR DESCRIPTION
This commit refactors the async::context memory management system to use a scheduler-provided allocator instead of requiring pre-allocated stack memory. The scheduler interface now includes a get_allocator() method that returns a polymorphic memory resource, and context objects now automatically allocate and deallocate their stack memory using this allocator.

Changes:

- Add get_allocator() virtual method to scheduler interface
- Update context constructor to accept stack size instead of strong_ptr to pre-allocated memory
- Implement automatic stack allocation/deallocation in context using polymorphic allocator
- Update strong_ptr dependency from 0.0.2 to 0.1.2
- Add stricter compiler flags (-Werror, -Wall, -Wextra, -Wshadow, -fexceptions, -fno-rtti)
- Update tests to implement new allocator interface

Resolves #18 