### PR TITLE
:recycle: extend async context blocking mechanisms and add comprehensive tests

### DIFF
--- a/git-town.toml
+++ b/git-town.toml
@@ -1,0 +1,8 @@
+# See https://www.git-town.com/configuration-file for details
+
+[branches]
+main = "main"
+
+[hosting]
+forge-type = "github"
+github-connector-type = "gh"

--- a/test_package/main.cpp
+++ b/test_package/main.cpp
@@ -22,22 +22,21 @@
 
 import async_context;
 
-struct my_scheduler
+struct test_scheduler
   : public async::scheduler
-  , mem::enable_strong_from_this<my_scheduler>
+  , mem::enable_strong_from_this<test_scheduler>
 {
   int sleep_count = 0;
 
-  my_scheduler(mem::strong_ptr_only_token)
+  test_scheduler(mem::strong_ptr_only_token)
   {
   }
 
 private:
-  void do_schedule(
-    [[maybe_unused]] async::context& p_context,
-    [[maybe_unused]] async::blocked_by p_block_state,
-    [[maybe_unused]] std::variant<std::chrono::nanoseconds, async::context*>
-      p_block_info) override
+  void do_schedule([[maybe_unused]] async::context& p_context,
+                   [[maybe_unused]] async::blocked_by p_block_state,
+                   [[maybe_unused]] async::scheduler::block_info
+                     p_block_info) noexcept override
   {
     if (std::holds_alternative<std::chrono::nanoseconds>(p_block_info)) {
       sleep_count++;
@@ -64,7 +63,7 @@ async::future<void> coro_double_delay(async::context&)
 int main()
 {
   auto scheduler =
-    mem::make_strong_ptr<my_scheduler>(std::pmr::new_delete_resource());
+    mem::make_strong_ptr<test_scheduler>(std::pmr::new_delete_resource());
   async::context my_context(scheduler, 1024);
 
   auto future_delay = coro_double_delay(my_context);

--- a/tests/async.test.cpp
+++ b/tests/async.test.cpp
@@ -12,18 +12,100 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <array>
 #include <chrono>
 #include <coroutine>
 #include <memory_resource>
-#include <span>
+#include <ostream>
+#include <source_location>
 #include <variant>
 
 #include <boost/ut.hpp>
 
 import async_context;
 
+namespace async {
+std::ostream& operator<<(std::ostream& out, blocked_by b)
+{
+  switch (b) {
+    case blocked_by::nothing:
+      return out << "nothing";
+    case blocked_by::time:
+      return out << "time";
+    case blocked_by::io:
+      return out << "io";
+    case blocked_by::sync:
+      return out << "sync";
+    case blocked_by::external:
+      return out << "external";
+    default:
+      // For unknown values we print the numeric value
+      return out << "blocked_by(" << static_cast<std::uint8_t>(b) << ')';
+  }
+}
+}  // namespace async
+
 bool resumption_occurred = false;
+struct test_scheduler
+  : public async::scheduler
+  , mem::enable_strong_from_this<test_scheduler>
+{
+  int sleep_count = 0;
+  async::context* sync_context = nullptr;
+  bool io_block = false;
+
+  test_scheduler(mem::strong_ptr_only_token)
+  {
+  }
+
+private:
+  void do_schedule([[maybe_unused]] async::context& p_context,
+                   [[maybe_unused]] async::blocked_by p_block_state,
+                   [[maybe_unused]] async::scheduler::block_info
+                     p_block_info) noexcept override
+  {
+    std::println("Scheduler called!", sleep_count);
+
+    switch (p_block_state) {
+      case async::blocked_by::time: {
+        if (std::holds_alternative<std::chrono::nanoseconds>(p_block_info)) {
+          std::println("sleep for: {}",
+                       std::get<std::chrono::nanoseconds>(p_block_info));
+          sleep_count++;
+          std::println("Sleep count = {}!", sleep_count);
+        }
+        break;
+      }
+      case async::blocked_by::sync: {
+        if (std::holds_alternative<async::context*>(p_block_info)) {
+          auto* context = std::get<async::context*>(p_block_info);
+          std::println(
+            "Coroutine ({}) is blocked by syncronization with coroutine ({})",
+            static_cast<void*>(&p_context),
+            static_cast<void*>(context));
+          sync_context = context;
+        }
+        break;
+      }
+      case async::blocked_by::io: {
+        io_block = true;
+        break;
+      }
+      case async::blocked_by::nothing: {
+        std::println("Context ({}) has been unblocked!",
+                     static_cast<void*>(&p_context));
+        break;
+      }
+      default: {
+        break;
+      }
+    }
+  }
+
+  std::pmr::memory_resource& do_get_allocator() noexcept override
+  {
+    return *strong_from_this().get_allocator();
+  }
+};
 
 async::future<void> coro_print(async::context&)
 {
@@ -36,44 +118,14 @@ async::future<void> coro_print(async::context&)
 }
 
 namespace async {
-boost::ut::suite<"async::context"> async_context_suite = []() {
+void async_context_suite()
+{
   using namespace boost::ut;
 
-  "<TBD>"_test = []() {
-    struct my_scheduler
-      : public async::scheduler
-      , mem::enable_strong_from_this<my_scheduler>
-    {
-      int sleep_count = 0;
-
-      my_scheduler(mem::strong_ptr_only_token)
-      {
-      }
-
-    private:
-      void do_schedule(
-        [[maybe_unused]] context& p_context,
-        [[maybe_unused]] blocked_by p_block_state,
-        [[maybe_unused]] std::variant<std::chrono::nanoseconds, context*>
-          p_block_info) override
-      {
-        std::println("Scheduler called!", sleep_count);
-        if (std::holds_alternative<std::chrono::nanoseconds>(p_block_info)) {
-          std::println("sleep for: {}",
-                       std::get<std::chrono::nanoseconds>(p_block_info));
-          sleep_count++;
-          std::println("Sleep count = {}!", sleep_count);
-        }
-      }
-
-      std::pmr::memory_resource& do_get_allocator() noexcept override
-      {
-        return *strong_from_this().get_allocator();
-      }
-    };
+  "coroutine with time-based blocking and sync_wait"_test = []() {
     // Setup
     auto scheduler =
-      mem::make_strong_ptr<my_scheduler>(std::pmr::new_delete_resource());
+      mem::make_strong_ptr<test_scheduler>(std::pmr::new_delete_resource());
     async::context my_context(scheduler, 1024);
 
     // Exercise
@@ -84,6 +136,160 @@ boost::ut::suite<"async::context"> async_context_suite = []() {
     expect(that % resumption_occurred);
     expect(that % future_print.done());
     expect(that % 2 == scheduler->sleep_count);
+  };
+
+  "block_by_io and block_by_sync notify scheduler correctly"_test = []() {
+    // Setup
+    auto scheduler =
+      mem::make_strong_ptr<test_scheduler>(std::pmr::new_delete_resource());
+    async::context my_context(scheduler, 1024);
+    async::context my_context2(scheduler, 1024);
+
+    resumption_occurred = false;
+
+    auto test_coro =
+      [&my_context2](async::context& p_context) -> async::future<void> {
+      using namespace std::chrono_literals;
+      std::println("Printed from a coroutine");
+      co_await 100ns;
+      resumption_occurred = true;
+      co_await p_context.block_by_io();
+      co_await p_context.block_by_sync(&my_context2);
+      co_return;
+    };
+
+    // Exercise
+    auto blocked_by_testing = test_coro(my_context);
+    expect(that % not resumption_occurred);
+    blocked_by_testing.sync_wait();
+
+    // Verify
+    expect(that % resumption_occurred);
+    expect(that % blocked_by_testing.done());
+    expect(that % scheduler->io_block);
+    expect(that % &my_context2 == scheduler->sync_context);
+  };
+
+  "mutex-like resource synchronization between coroutines"_test = []() {
+    // Setup
+    auto scheduler =
+      mem::make_strong_ptr<test_scheduler>(std::pmr::new_delete_resource());
+    async::context my_context1(scheduler, 1024);
+    async::context my_context2(scheduler, 1024);
+
+    async::context_token io_in_use;
+
+    auto single_resource =
+      [&](async::context& p_context) -> async::future<void> {
+      using namespace std::chrono_literals;
+
+      std::println("Executing 'single_resource' coroutine");
+      while (io_in_use) {
+        std::println("Resource unavailable, blocked by {}",
+                     io_in_use.address());
+        co_await io_in_use.set_as_block_by_sync(p_context);
+      }
+
+      // Block next coroutine from using this resource
+      io_in_use = p_context;
+
+      // It cannot be assumed that the scheduler will not sync_wait() this
+      // coroutine, thus, a loop is required to sure that the async operation
+      // has actually completed.
+      while (io_in_use == p_context) {
+        std::println("Waiting on io complete flag, blocking by I/O");
+        // Continually notify that this is blocked by IO
+        co_await p_context.block_by_io();
+      }
+
+      std::println("IO operation complete! Returning!");
+
+      co_return;
+    };
+
+    std::println("🧱 Future setup");
+    auto access_first = single_resource(my_context1);
+    auto access_second = single_resource(my_context2);
+
+    auto check_access_first_blocked_by =
+      [&](async::blocked_by p_state = async::blocked_by::io,
+          std::source_location const& p_location =
+            std::source_location::current()) {
+        expect(that % my_context1.state() ==
+               access_first.handle().promise().get_context().state())
+          << "line: " << p_location.line() << '\n';
+        expect(that % static_cast<int>(p_state) ==
+               static_cast<int>(my_context1.state()))
+          << "line: " << p_location.line() << '\n';
+        ;
+      };
+
+    auto check_access_second_blocked_by =
+      [&](async::blocked_by p_state = async::blocked_by::nothing,
+          std::source_location const& p_location =
+            std::source_location::current()) {
+        expect(that % my_context2.state() ==
+               access_second.handle().promise().get_context().state())
+          << "line: " << p_location.line() << '\n';
+        ;
+        expect(that % p_state == my_context2.state())
+          << "line: " << p_location.line() << '\n';
+        ;
+      };
+
+    // access_first will claim the resource and will return control, and be
+    // blocked by IO.
+    std::println("▶️ Resume 1st: 1");
+    access_first.resume();
+
+    check_access_first_blocked_by();
+    check_access_second_blocked_by();
+
+    std::println("▶️ Resume 1st: 2");
+    access_first.resume();
+
+    check_access_first_blocked_by();
+    check_access_second_blocked_by();
+
+    std::println("▶️ Resume 1st: 3");
+    access_first.resume();
+
+    check_access_first_blocked_by();
+    check_access_second_blocked_by();
+
+    std::println("▶️ Resume 2nd: 1");
+    access_second.resume();
+
+    check_access_first_blocked_by();
+    check_access_second_blocked_by(async::blocked_by::sync);
+
+    io_in_use.unblock_and_clear();
+
+    check_access_first_blocked_by(async::blocked_by::nothing);
+    check_access_second_blocked_by(async::blocked_by::sync);
+
+    std::println("▶️ Resume 2nd: 2");
+    access_second.resume();
+
+    // Resuming access_second shouldn't change the state of anything
+    check_access_first_blocked_by(async::blocked_by::nothing);
+    check_access_second_blocked_by(async::blocked_by::io);
+
+    std::println("▶️ Resume 1st: 4, this should finish the operation");
+    access_first.resume();
+
+    expect(that % my_context1.state() == async::blocked_by::nothing);
+    expect(that % access_first.done());
+
+    check_access_second_blocked_by(async::blocked_by::io);
+    access_second.resume();
+    check_access_second_blocked_by(async::blocked_by::io);
+
+    io_in_use.unblock_and_clear();
+    access_second.resume();
+
+    expect(that % my_context2.state() == async::blocked_by::nothing);
+    expect(that % access_second.done());
   };
 };
 }  // namespace async

--- a/tests/main.test.cpp
+++ b/tests/main.test.cpp
@@ -14,12 +14,14 @@
 
 // export module libahl_unit_tests;
 
-namespace hal {
+namespace async {
 // Extern position dependant test go here. Refrain from using this whenever
 // possible.
-}  // namespace hal
+extern void async_context_suite();
+}  // namespace async
 
 int main()
 {
   // Position dependent test go below:
+  async::async_context_suite();
 }


### PR DESCRIPTION
This commit significantly expands the async context API to support multiple blocking states and adds extensive test coverage. Key changes include:

- Add new blocking methods: block_by_sync() with context pointer, and block_by_external() to support different synchronization patterns
- Make blocking methods return std::suspend_always for improved coroutine suspension ergonomics
- Add context_token class for safe context capture and unblocking operations
- Enhance context state queries with safer std::holds_alternative checks
- Add git-town configuration for workflow management
- Add comprehensive test suite demonstrating resource synchronization patterns between coroutines, including mutex-like behavior and I/O blocking scenarios
- Refactor test infrastructure with reusable test_scheduler implementation.

These enhancements enable more sophisticated coroutine coordination patterns while maintaining the lightweight design of the async context system.