### PR TITLE
:sparkles: Add `run_until_done` scheduling algorithm 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,10 @@ project(async_context LANGUAGES CXX)
 find_package(LibhalCMakeUtil REQUIRED)
 
 libhal_project_init()
-libhal_add_library(async_context MODULES modules/async_context.cppm)
+libhal_add_library(async_context
+    MODULES
+        modules/async_context.cppm
+        modules/schedulers.cppm)
 libhal_apply_compile_options(async_context)
 libhal_install_library(async_context NAMESPACE libhal)
 libhal_add_tests(async_context
@@ -35,6 +38,8 @@ libhal_add_tests(async_context
         basics_dep_inject
         on_unblock
         simple_scheduler
+        clock_adapter
+        run_until_done
 
     MODULES
         tests/util.cppm

--- a/README.md
+++ b/README.md
@@ -22,14 +22,12 @@ performance.
 > 1.0.0 release.
 
 ```C++
-#include <cassert>
-
 #include <chrono>
-#include <coroutine>
 #include <print>
 #include <thread>
 
 import async_context;
+import async_context.schedulers;
 
 using namespace std::chrono_literals;
 
@@ -77,38 +75,45 @@ async::future<void> sensor_pipeline(async::context& ctx,
   std::println("Pipeline '{}' complete!\n", p_name);
 }
 
+// Unblocks any I/O-blocked context in ctx1 or ctx2 (simulates hardware
+// callbacks completing). Runs as a third coroutine alongside the pipelines.
+async::future<void> io_unblock_driver(async::context& p_ctx,
+                                      async::context& ctx1,
+                                      async::context& ctx2)
+{
+  while (true) {
+    if (ctx1.done() && ctx2.done()) {
+      co_return;
+    }
+    if (ctx1.state() == async::blocked_by::io) {
+      ctx1.unblock();
+    }
+    if (ctx2.state() == async::blocked_by::io) {
+      ctx2.unblock();
+    }
+    co_await 1us;
+  }
+}
+
 int main()
 {
-  // Create context and add them to the scheduler
-  basic_context<8192> ctx1(scheduler);
-  basic_context<8192> ctx2(scheduler);
+  async::inplace_context<512> ctx1;
+  async::inplace_context<512> ctx2;
+  async::inplace_context<512> driver_ctx;
 
-  // Run two independent pipelines concurrently
+  // Start the two pipelines and the I/O unblock driver
   auto pipeline1 = sensor_pipeline(ctx1, "🌟 System 1");
   auto pipeline2 = sensor_pipeline(ctx2, "🔥 System 2");
+  auto driver    = io_unblock_driver(driver_ctx, ctx1, ctx2);
 
-  // Round robin between each context
-  while (true) {
-   bool all_done = true;
-   for (auto& ctx : std::to_array({&ctx1, &ctx2}) {
-     if (not ctx->done()) {
-       all_done = false;
-       if (ctx->state() == async::blocked_by::nothing) {
-         ctx->resume();
-       }
-       if (ctx->state() == async::blocked_by::time) {
-         std::this_thread::sleep(ctx.pending_delay());
-         ctx.unblock();
-       }
-     }
-   }
-   if (all_done) {
-     break;
-   }
-  }
-
-  assert(pipeline1.done());
-  assert(pipeline2.done());
+  // Drive all three contexts to completion.
+  // run_until_done sleeps until the nearest time deadline when all contexts
+  // are blocked, and wakes immediately when any context becomes ready.
+  async::chrono_clock_adapter<std::chrono::steady_clock> clk;
+  async::run_until_done(
+    clk,
+    [](auto p_wake_time) { std::this_thread::sleep_until(p_wake_time); },
+    ctx1, ctx2, driver_ctx);
 
   std::println("Both pipelines completed successfully!");
   return 0;
@@ -285,6 +290,90 @@ An enum describing what a coroutine is blocked by:
 The state of this can be found from the `async::context::state()`. All states
 besides time are safe to resume at any point. If a context has been blocked by
 time, then it must defer calling resume until that time has elapsed.
+
+## Schedulers
+
+You can import the schedulers by importing `async_context.schedulers`. Importing
+`async_context.schedulers` also transitively imports `async_context`.
+
+### `async::clock` (concept)
+
+An instance-based clock concept. Unlike `std::chrono` clocks which require a
+static `now()`, `async::clock` requires an instance method so hardware clocks
+can be injected as runtime objects. A conforming type must provide:
+
+- `time_point` — the type returned by `now()`
+- `duration` — the difference type of two `time_point`s
+- `now() const` — returns the current `time_point`
+- `time_point` arithmetic: subtraction yields `duration`, addition of
+  `duration` yields `time_point`
+- `time_point::max()` — sentinel meaning "never wake"
+
+### `async::chrono_clock_adapter<ChronoClock>`
+
+A zero-size adapter that wraps any `std::chrono`-conforming clock (with a
+static `now()`) into an `async::clock` (with an instance `now()`). Because it
+holds no state, it is always optimized away entirely by the compiler.
+
+```cpp
+async::chrono_clock_adapter<std::chrono::steady_clock> clk;
+static_assert(async::clock<decltype(clk)>);
+
+auto now = clk.now(); // forwards to std::chrono::steady_clock::now()
+```
+
+Use this on hosted platforms. On bare-metal, implement `async::clock` directly
+against your hardware timer peripheral.
+
+### `async::run_until_done`
+
+Drives a fixed set of `async::context` objects to completion in a cooperative
+scheduling loop. On each iteration it resumes every context that is ready or
+whose time deadline has elapsed. When all remaining contexts are blocked, it
+calls the user-supplied `p_sleep_until` callable to suspend the CPU until the
+nearest deadline.
+
+```cpp
+// Without interruptible sleep
+async::run_until_done(
+  clk,
+  [](auto p_wake_time) { std::this_thread::sleep_until(p_wake_time); },
+  ctx0, ctx1, ctx2);
+```
+
+An overload accepts an `async::unblock_listener` as a third argument. The
+listener is registered on every context so that an I/O completion or ISR can
+wake `p_sleep_until` early, avoiding unnecessary latency when all contexts are
+time-blocked but an I/O event arrives before the deadline.
+
+```cpp
+async::run_until_done(
+  clk,
+  [](auto p_wake_time) {
+    // sleep until the deadline OR until woken by the listener below
+    platform_sleep_until(p_wake_time);
+  },
+  async::unblock_listener::from([](async::context& p_ctx) noexcept {
+    // called from ISR/thread when any context is unblocked
+    platform_wake_from_sleep();
+  }),
+  ctx0, ctx1, ctx2);
+```
+
+Key properties:
+
+- **Stack-allocated scheduler table** — no heap allocation; all internal
+  bookkeeping lives on the call stack and is destroyed when the function
+  returns, even on exception
+- **Listener lifetime safety** — every context's listener registration is
+  cleared in the destructor of the internal scheduler entry, so no context
+  can hold a dangling pointer after `run_until_done` returns
+- **Time-only sleep** — `p_sleep_until` is only called when all contexts are
+  time-blocked *and* none are immediately ready; it is never called if work
+  remains
+- **Exceptions** — any exception that propagates out of a coroutine is
+  re-thrown from `run_until_done`; all listener registrations are still
+  cleaned up via RAII before the exception escapes
 
 ## Usage
 
@@ -570,4 +659,4 @@ set(BUILD_BENCHMARKS OFF)
 
 Apache License 2.0 - See [LICENSE](LICENSE) for details.
 
-Copyright 2024 - 2025 Khalil Estell and the libhal contributors
+Copyright 2024 - 2026 Khalil Estell and the libhal contributors

--- a/cspell.json
+++ b/cspell.json
@@ -51,7 +51,8 @@
     "doxygenfunction",
     "doxygenenum",
     "alignof",
-    "inplace"
+    "inplace",
+    "interruptible"
   ],
   "ignorePaths": [
     "build/",

--- a/modules/async_context.cppm
+++ b/modules/async_context.cppm
@@ -1,4 +1,4 @@
-// Copyright 2024 - 2025 Khalil Estell and the libhal contributors
+// Copyright 2024 - 2026 Khalil Estell and the libhal contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -333,7 +333,7 @@ public:
       }
 
     private:
-      void on_unblock(async::context const& p_context) noexcept override
+      void on_unblock(async::context& p_context) noexcept override
       {
         handler(p_context);
       }
@@ -362,7 +362,7 @@ private:
    * @note This method MUST be noexcept and ISR-safe. It may be called from
    * any execution context including interrupt handlers.
    */
-  virtual void on_unblock(context const& p_context) noexcept = 0;
+  virtual void on_unblock(context& p_context) noexcept = 0;
 };
 
 /**
@@ -499,8 +499,6 @@ public:
    */
   constexpr void unblock_without_notification() noexcept
   {
-    // We clear this information after the unblock call to allow the unblock
-    // call to inspect the context's current state.
     get_original().m_state = blocked_by::nothing;
     get_original().m_sleep_time = sleep_duration::zero();
     get_original().m_sync_blocker = nullptr;
@@ -526,6 +524,10 @@ public:
     if (get_original().m_listener) {
       get_original().m_listener->on_unblock(*this);
     }
+
+    // We clear this context state information after the unblock listener is
+    // invoked to allow the unblock listener to inspect the context's current
+    // state prior to being unblocked.
     unblock_without_notification();
   }
 
@@ -664,8 +666,11 @@ public:
    */
   void resume()
   {
-    // We cannot resume the a coroutine blocked by time.
-    // Only the scheduler can unblock a context state.
+    // We cannot resume the a coroutine blocked by time. Only the scheduler can
+    // unblock a context state.
+    //
+    // This needs to be here to ensure that sync_wait is possible, otherwise the
+    // blocked_by::time semantic cannot be supported.
     if (state() != blocked_by::time) {
       m_active_handle.resume();
     }
@@ -924,15 +929,16 @@ private:
     return coroutine_frame_stack_address;
   }
 
+  // A concern for this library is how large the context objet is thus the word
+  // sizes for each field is denoted below.
   std::coroutine_handle<> m_active_handle = noop_sentinel;  // word 1
   uptr* m_stack_pointer = nullptr;                          // word 2
   std::span<uptr> m_stack{};                                // word 3-4
   context* m_original = nullptr;                            // word 5
-  // ----------- Only available from the original -----------
-  unblock_listener* m_listener = nullptr;                // word 6
-  sleep_duration m_sleep_time = sleep_duration::zero();  // word 7
-  context* m_sync_blocker = nullptr;                     // word 8
-  blocked_by m_state = blocked_by::nothing;              // word 9: pad 3
+  unblock_listener* m_listener = nullptr;                   // word 6
+  sleep_duration m_sleep_time = sleep_duration::zero();     // word 7
+  context* m_sync_blocker = nullptr;                        // word 8
+  blocked_by m_state = blocked_by::nothing;                 // word 9: pad 3
 };
 
 /**
@@ -1078,8 +1084,8 @@ public:
 
   inplace_context(inplace_context const&) = delete;
   inplace_context& operator=(inplace_context const&) = delete;
-  inplace_context(inplace_context&&) = default;
-  inplace_context& operator=(inplace_context&&) = default;
+  inplace_context(inplace_context&&) = delete;
+  inplace_context& operator=(inplace_context&&) = delete;
 
   ~inplace_context()
   {

--- a/modules/schedulers.cppm
+++ b/modules/schedulers.cppm
@@ -1,0 +1,316 @@
+// Copyright 2024 - 2026 Khalil Estell and the libhal contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module;
+
+#include <cstddef>
+
+#include <chrono>
+#include <concepts>
+#include <coroutine>
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+export module async_context.schedulers;
+
+export import async_context;
+
+namespace async::inline v0 {
+/**
+ * @brief Concept for an instance-based clock.
+ *
+ * Deliberately does NOT require static now() — unlike std::chrono clock types
+ * — so that hardware clocks can be injected as runtime objects. Any
+ * std::chrono clock can be adapted via chrono_clock_adapter.
+ *
+ * A conforming type must provide:
+ *   - time_point  : the type returned by now()
+ *   - duration    : the difference type of two time_points
+ *   - now()       : const member returning time_point
+ *   - time_point arithmetic (subtraction -> duration, addition of duration)
+ *   - time_point::max() sentinel for "never"
+ */
+export template<typename T>
+concept clock = requires(T const t, typename T::time_point tp) {
+  typename T::time_point;
+  typename T::duration;
+  { t.now() } -> std::same_as<typename T::time_point>;
+  { tp - tp } -> std::convertible_to<typename T::duration>;
+  { tp + typename T::duration{} } -> std::same_as<typename T::time_point>;
+  { T::time_point::max() } -> std::same_as<typename T::time_point>;
+};
+
+/**
+ * @brief Adapts any std::chrono-conforming clock (static now()) into an
+ * async::clock (instance now()).
+ *
+ * Zero-size type — all state lives in the underlying static clock. The
+ * instance now() simply forwards, so this is always optimized away entirely.
+ *
+ * Example:
+ *   async::chrono_clock_adapter<std::chrono::steady_clock> clk;
+ *   static_assert(async::clock<decltype(clk)>);
+ */
+export template<typename ChronoClock>
+  requires requires {
+    { ChronoClock::now() } -> std::same_as<typename ChronoClock::time_point>;
+    typename ChronoClock::duration;
+  }
+struct chrono_clock_adapter
+{
+  using duration = typename ChronoClock::duration;
+  using time_point = typename ChronoClock::time_point;
+
+  [[nodiscard]] time_point now() const noexcept(noexcept(ChronoClock::now()))
+  {
+    return ChronoClock::now();
+  }
+};
+
+// =============================================================================
+
+/**
+ * @brief Internal scheduler entry binding one context to the run_until_done
+ * loop.
+ *
+ * Associates a context reference with an absolute wake deadline and owns the
+ * unblock listener registration on that context. On construction (via assign())
+ * the listener is registered; on destruction it is unconditionally cleared,
+ * ensuring the context never holds a dangling listener pointer after the
+ * enclosing run_until_done_impl stack frame is gone.
+ *
+ * @note Not copyable or movable — the array of scheduled_context objects is
+ * stack-allocated inside run_until_done_impl and never escapes that scope.
+ *
+ * @tparam Clock Any type satisfying async::clock.
+ */
+template<clock Clock>
+struct scheduled_context
+{
+  using time_point = typename Clock::time_point;
+
+  std::reference_wrapper<context> ctx;
+  time_point wake_time = time_point::max();
+
+  scheduled_context(async::context& p_ctx,
+                    async::unblock_listener* p_listener,
+                    Clock const& p_clock)
+    : ctx(p_ctx)
+  {
+    p_ctx.on_unblock(p_listener);
+    refresh(p_clock);
+  }
+
+  // Bind this entry to p_ctx, register p_listener (may be nullptr), and
+  // compute the initial wake_time. Must be called exactly once before any
+  // other method.
+  void assign(async::context& p_ctx,
+              async::unblock_listener* p_listener,
+              Clock const& p_clock)
+  {
+    ctx = p_ctx;
+    p_ctx.on_unblock(p_listener);
+    refresh(p_clock);
+  }
+
+  // Recompute wake_time from the context's current sleep_time. Called after
+  // every resume because the blocking state may have changed.
+  void refresh(Clock const& p_clock)
+  {
+    if (ctx.get().state() == blocked_by::time) {
+      wake_time = p_clock.now() + ctx.get().sleep_time();
+    } else {
+      wake_time = time_point::max();
+    }
+  }
+
+  /**
+   * @brief Resume the context if its deadline has elapsed or it is otherwise
+   * ready, then refresh wake_time to reflect the new state.
+   *
+   * @param p_clock - clock to get the current time from
+   * @return true - context was resumed
+   * @return false - context is done
+   */
+  void resume(Clock const& p_clock)
+  {
+    if (ctx.get().state() == blocked_by::time && wake_time <= p_clock.now()) {
+      // Deadline elapsed — unblock without triggering scheduler notification,
+      // since we are the scheduler, then resume.
+      ctx.get().unblock_without_notification();
+      ctx.get().resume();
+      // Recompute after resume — state may have changed.
+      refresh(p_clock);
+    } else if (is_ready()) {
+      ctx.get().resume();
+      // Recompute after resume — state may have changed.
+      refresh(p_clock);
+    }
+  }
+
+  // Returns true if the context is not blocked by time or I/O and can be
+  // resumed immediately.
+  [[nodiscard]] bool is_ready() const noexcept
+  {
+    return ctx.get().state() != blocked_by::io &&
+           ctx.get().state() != blocked_by::time;
+  }
+
+  [[nodiscard]] bool operator<(time_point const& p_other) const noexcept
+  {
+    return wake_time < p_other;
+  }
+
+  // Clear the unblock listener so the context does not hold a pointer into
+  // this stack frame after run_until_done_impl returns.
+  ~scheduled_context()
+  {
+    ctx.get().clear_unblock_listener();
+  }
+};
+
+/**
+ * @brief Concept for types derived from async::context
+ *
+ * This concept is satisfied by async::context and any type derived from it,
+ * such as proxy_context and inplace_context. It is used to constrain the
+ * variadic context parameters in run_until_done to ensure type safety.
+ *
+ * @tparam T The type to check
+ */
+export template<class T>
+concept context_derived = std::derived_from<T, context>;
+
+// Internal implementation — accepts a nullable listener pointer.
+// nullptr means no listener is registered (no interruptable sleep).
+template<clock Clock>
+void run_until_done_impl(
+  Clock& p_clock,
+  std::invocable<typename Clock::time_point> auto&& p_sleep_until,
+  async::unblock_listener* p_listener,
+  context_derived auto&... p_tasks)
+{
+  using time_point = typename Clock::time_point;
+  constexpr auto context_count = sizeof...(p_tasks);
+  constexpr auto max_wake = time_point::max();
+
+  // Stack-allocated scheduler table. Each entry holds a reference to its
+  // context and manages the unblock listener registration on that context.
+  // Because the array is destroyed when this function returns — whether by
+  // normal exit or exception — every scheduled_context destructor fires before
+  // the stack frame unwinds, guaranteeing that all listener pointers are
+  // cleared before p_listener (or p_sleep_until's internal primitive) could
+  // go out of scope. This makes listener lifetime management exception-safe
+  // with no additional cleanup code required.
+  std::array<scheduled_context<Clock>, context_count> tasks{
+    scheduled_context<Clock>{ p_tasks, p_listener, p_clock }...
+  };
+
+  while (true) {
+    time_point soonest_wake_time = max_wake;
+    bool all_done = true;
+    bool can_sleep = true;
+
+    for (auto& task : tasks) {
+      if (task.ctx.get().done()) {
+        continue;
+      }
+
+      all_done = false;
+
+      task.resume(p_clock);
+
+      // After resuming, re-evaluate whether we can sleep and what the
+      // soonest deadline is
+      if (task.wake_time < soonest_wake_time) {
+        soonest_wake_time = task.wake_time;
+      }
+
+      if (task.is_ready()) {
+        can_sleep = false;
+      }
+    }
+
+    if (all_done) {
+      break;
+    }
+
+    if (can_sleep && soonest_wake_time < max_wake) {
+      p_sleep_until(soonest_wake_time);
+    }
+  }
+}
+
+/**
+ * @brief Drives a set of async::context objects to completion.
+ *
+ * Runs a cooperative scheduling loop, resuming each context that is ready and
+ * sleeping (via p_sleep_until) when all contexts are either blocked by time or
+ * blocked by I/O.
+ *
+ * Exceptions that propagate out of the coroutine will be propagated out of this
+ * function.
+ *
+ * @tparam Clock - any type satisfying async::clock
+ *
+ * @param p_clock - clock used to compute and compare deadlines
+ * @param p_sleep_until - callable(Clock::time_point) that sleeps until the
+ * given absolute deadline. May return early if woken externally.
+ * @param p_tasks - list of contexts to drive.
+ */
+export template<clock Clock>
+void run_until_done(
+  Clock& p_clock,
+  std::invocable<typename Clock::time_point> auto&& p_sleep_until,
+  context_derived auto&... p_tasks)
+{
+  run_until_done_impl(p_clock,
+                      std::forward<decltype(p_sleep_until)>(p_sleep_until),
+                      nullptr,
+                      p_tasks...);
+}
+
+/**
+ * @brief Drives a set of async::context objects to completion with an
+ * interruptable sleep.
+ *
+ * Same as the two-parameter overload but registers p_listener on every context
+ * so that an I/O completion or ISR can wake the sleep function early.
+ *
+ * Exceptions that propagate out of the coroutine will be propagated out of this
+ * function.
+ *
+ * @tparam Clock - any type satisfying async::clock
+ *
+ * @param p_clock - clock used to compute and compare deadlines
+ * @param p_sleep_until - callable(Clock::time_point) that sleeps until the
+ * given absolute deadline or until woken via p_listener.
+ * @param p_listener - unblock listener wired to the sleep primitive so it
+ * returns early when an I/O operation completes.
+ * @param p_tasks - list of contexts to drive.
+ */
+export template<clock Clock>
+void run_until_done(
+  Clock& p_clock,
+  std::invocable<typename Clock::time_point> auto&& p_sleep_until,
+  async::unblock_listener&& p_listener,
+  context_derived auto&... p_tasks)
+{
+  run_until_done_impl(p_clock,
+                      std::forward<decltype(p_sleep_until)>(p_sleep_until),
+                      &p_listener,
+                      p_tasks...);
+}
+}  // namespace async::inline v0

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -46,6 +46,12 @@ target_compile_options(${PROJECT_NAME} PRIVATE
     -Wshadow
     -fexceptions
     -fno-rtti)
+
+if(NOT CMAKE_CROSSCOMPILING)
+    target_compile_options(${PROJECT_NAME} PRIVATE -fsanitize=address)
+    target_link_options(${PROJECT_NAME} PRIVATE -fsanitize=address)
+endif()
+
 # Always run this custom target by making it depend on ALL
 add_custom_target(copy_compile_commands ALL
     COMMAND ${CMAKE_COMMAND} -E copy_if_different

--- a/test_package/main.cpp
+++ b/test_package/main.cpp
@@ -17,6 +17,7 @@
 #include <coroutine>
 #include <memory>
 #include <print>
+#include <ratio>
 #include <variant>
 #include <vector>
 
@@ -25,23 +26,22 @@
 #endif
 
 import async_context;
+import async_context.schedulers;
+
+using namespace std::chrono_literals;
 
 // Simulates reading sensor data with I/O delay
 async::future<int> read_sensor(async::context& ctx, std::string_view p_name)
 {
-  using namespace std::chrono_literals;
-  std::println("['{}': Sensor] Starting read...", p_name);
-  co_await ctx.block_by_io();  // Simulate I/O operation
   std::println("['{}': Sensor] Read complete: 42", p_name);
   co_return 42;
 }
 
 // Processes data with computation delay
-async::future<int> process_data(async::context& ctx,
+async::future<int> process_data(async::context& p_ctx,
                                 std::string_view p_name,
                                 int value)
 {
-  using namespace std::chrono_literals;
   std::println("['{}': Process] Processing {}...", p_name, value);
   co_await 10ms;  // Simulate processing time
   int result = value * 2;
@@ -49,13 +49,12 @@ async::future<int> process_data(async::context& ctx,
   co_return result;
 }
 
-// Writes result with I/O delay
-async::future<void> write_actuator(async::context& ctx,
+async::future<void> write_actuator(async::context& p_ctx,
                                    std::string_view p_name,
                                    int value)
 {
   std::println("['{}': Actuator] Writing {}...", p_name, value);
-  co_await ctx.block_by_io();
+  co_await p_ctx.block_by_io();
   std::println("['{}': Actuator] Write complete!", p_name);
 }
 
@@ -72,94 +71,67 @@ async::future<void> sensor_pipeline(async::context& ctx,
   std::println("Pipeline '{}' complete!\n", p_name);
 }
 
-// Type-erased future wrapper for storing different future types
-struct future_wrapper
+// Stub implementation for ARM M Cortex targets without
+// std::chrono::steady_clock
+struct stub_clock
 {
-  virtual void resume() = 0;
-  [[nodiscard]] virtual bool done() const = 0;
-  virtual ~future_wrapper() = default;
-};
+  using duration = std::chrono::nanoseconds;
+  using rep = duration::rep;
+  using period = duration::period;
+  using time_point = std::chrono::time_point<stub_clock>;
+  static constexpr bool is_steady = false;
 
-template<typename T>
-class typed_future_wrapper : public future_wrapper
-{
-public:
-  explicit typed_future_wrapper(async::future<T>&& p_future)
-    : m_future(std::move(p_future))
+  static time_point now() noexcept
   {
+    return time_point(duration(0));
   }
-
-  void resume() override
-  {
-    m_future.resume();
-  }
-
-  [[nodiscard]] bool done() const override
-  {
-    return m_future.done();
-  }
-
-private:
-  async::future<T> m_future;
-};
-
-template<typename T>
-auto make_future_wrapper(async::future<T>&& p_future)
-{
-  return std::make_unique<typed_future_wrapper<T>>(std::move(p_future));
-}
-
-template<std::size_t ContextCount = 2, std::size_t ContextSize = 1024>
-struct round_robin_scheduler
-{
-  bool resume_n(int p_iterations)
-  {
-    for (int i = 0; i < p_iterations; i++) {
-      bool all_done = true;
-      for (auto& ctx : std::span(m_context_list).first(m_context_size)) {
-        if (not ctx.done()) {
-          all_done = false;
-          if (ctx.state() == async::blocked_by::nothing) {
-            ctx.resume();
-#if not __ARM_EABI__
-            std::this_thread::sleep_for(ctx.sleep_time());
-#endif
-            ctx.unblock();  // simulate quick unblocking of the context.
-          }
-        }
-      }
-      if (all_done) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  template<typename AsyncOperation, typename... OperationArgs>
-  void schedule_operation(AsyncOperation&& p_async_operation,
-                          OperationArgs... args)
-  {
-
-    auto future = p_async_operation(m_context_list[m_context_size], args...);
-    future_list[m_context_size] = make_future_wrapper(std::move(future));
-    m_context_size++;
-  }
-
-  std::array<async::inplace_context<ContextSize>, ContextCount>
-    m_context_list{};
-  std::array<std::unique_ptr<future_wrapper>, ContextCount> future_list{};
-  unsigned m_context_size = 0;
 };
 
 int main()
 {
-  round_robin_scheduler scheduler;
+#if __ARM_EABI__
+  async::chrono_clock_adapter<stub_clock> clk;
+#else
+  async::chrono_clock_adapter<std::chrono::steady_clock> clk;
+#endif
+
+  async::inplace_context<512> ctx0;
+  async::inplace_context<512> ctx1;
+  async::inplace_context<512> unblock_context;
 
   // Run two independent pipelines concurrently
-  scheduler.schedule_operation(sensor_pipeline, "🌟 System 1");
-  scheduler.schedule_operation(sensor_pipeline, "🔥 System 2");
+  auto pipeline1_future = sensor_pipeline(ctx0, "🌟 System 1");
+  auto pipeline2_future = sensor_pipeline(ctx1, "🔥 System 2");
+  // This is needed to simulate the context being unblocked by an external
+  // callback.
+  auto unblock_function =
+    [&ctx0, &ctx1](async::context& p_ctx) -> async::future<void> {
+    while (true) {
+      if (ctx0.done() and ctx1.done()) {
+        break;
+      }
+      if (ctx0.state() == async::blocked_by::io) {
+        ctx0.unblock();
+      }
+      if (ctx1.state() == async::blocked_by::io) {
+        ctx1.unblock();
+      }
+      co_await 1us;
+    }
+  };
 
-  scheduler.resume_n(100);
+  auto unblock_future = unblock_function(unblock_context);
+
+  auto stub_sleep_function = [](auto p_wake_time) {
+#if __ARM_EABI__
+    static_cast<void>(p_wake_time);  // ignore parameter
+#else
+    std::this_thread::sleep_until(p_wake_time);
+#endif
+  };
+
+  // Run ctx0, ctx1 and unblock_context to completion
+  async::run_until_done(clk, stub_sleep_function, ctx0, ctx1, unblock_context);
 
   std::println("Both pipelines completed successfully!");
   return 0;

--- a/tests/clock_adapter.test.cpp
+++ b/tests/clock_adapter.test.cpp
@@ -1,0 +1,13 @@
+#include <chrono>
+#include <type_traits>
+
+import async_context.schedulers;
+
+static_assert(
+  std::is_empty_v<async::chrono_clock_adapter<std::chrono::steady_clock>>);
+static_assert(
+  async::clock<async::chrono_clock_adapter<std::chrono::steady_clock>>);
+
+int main()
+{
+}

--- a/tests/on_unblock.test.cpp
+++ b/tests/on_unblock.test.cpp
@@ -73,7 +73,7 @@ void on_upload_test()
       bool unblock_called = false;
       async::context const* unblocked_context = nullptr;
 
-      void on_unblock(async::context const& p_context) noexcept override
+      void on_unblock(async::context& p_context) noexcept override
       {
         unblock_called = true;
         unblocked_context = &p_context;

--- a/tests/run_until_done.test.cpp
+++ b/tests/run_until_done.test.cpp
@@ -1,0 +1,156 @@
+#include <atomic>
+#include <cassert>
+#include <chrono>
+#include <coroutine>
+#include <future>
+#include <mutex>
+#include <print>
+#include <thread>
+#include <vector>
+
+#include <boost/ut.hpp>
+
+import async_context;
+import async_context.schedulers;
+
+using namespace std::chrono_literals;
+
+async::task sleeping_task(async::context& p_ctx,
+                          std::string_view p_name,
+                          async::sleep_duration p_sleep_time)
+{
+  std::println("[{}] Starting...", p_name);
+
+  for (int i = 1; i <= 5; i++) {
+    co_await p_sleep_time;
+    std::println("[{}] sleep {}", p_name, i);
+  }
+  co_return;
+}
+
+async::task blocking_task(async::context& p_ctx,
+                          async::sleep_duration p_sleep_time)
+{
+  std::atomic_bool simulated_hardware_busy = true;
+
+  auto t = std::jthread([&]() {
+    std::this_thread::sleep_for(1000ms);
+    std::println("Unblocking context: {}", static_cast<void*>(&p_ctx));
+    simulated_hardware_busy = false;
+    p_ctx.unblock();
+  });
+
+  co_await p_sleep_time;
+
+  while (simulated_hardware_busy) {
+    co_await p_ctx.block_by_io();
+  }
+
+  co_return;
+}
+
+void run_sleep_task_test()
+{
+  using namespace boost::ut;
+  using namespace std::chrono_literals;
+
+  async::inplace_context<512> ctx0;
+  async::inplace_context<512> ctx1;
+  async::inplace_context<512> ctx2;
+  async::inplace_context<512> ctx3;
+  async::inplace_context<512> ctx4;
+  async::inplace_context<512> ctx5;
+
+  "run_until_done"_test = [&]() {
+    // Setup
+    async::chrono_clock_adapter<std::chrono::steady_clock> clk;
+
+    std::vector<async::task> future_set;
+
+    future_set.push_back(sleeping_task(ctx0, "A", 55ms));
+    future_set.push_back(sleeping_task(ctx1, "B", 60ms));
+    future_set.push_back(sleeping_task(ctx2, "C", 65ms));
+    future_set.push_back(sleeping_task(ctx3, "D", 70ms));
+    future_set.push_back(sleeping_task(ctx4, "E", 75ms));
+    future_set.push_back(sleeping_task(ctx5, "F", 100ms));
+
+    // Exercise
+    async::run_until_done(
+      clk,
+      [](auto p_wake_time) { std::this_thread::sleep_until(p_wake_time); },
+      // List of tasks
+      ctx0,
+      ctx1,
+      ctx2,
+      ctx3,
+      ctx4,
+      ctx5);
+
+    // Verify
+    expect(future_set[0].done()) << "Context 0 didn't finish!";
+    expect(future_set[1].done()) << "Context 1 didn't finish!";
+    expect(future_set[2].done()) << "Context 2 didn't finish!";
+    expect(future_set[3].done()) << "Context 3 didn't finish!";
+    expect(future_set[4].done()) << "Context 4 didn't finish!";
+    expect(future_set[5].done()) << "Context 5 didn't finish!";
+  };
+
+  "run_until_done with unblock listener"_test = [&]() {
+    // Setup
+    async::chrono_clock_adapter<std::chrono::steady_clock> clk;
+    std::vector<async::task> future_set;
+
+    future_set.push_back(blocking_task(ctx0, 0ms));
+    future_set.push_back(blocking_task(ctx1, 10ms));
+    future_set.push_back(blocking_task(ctx2, 20ms));
+    future_set.push_back(blocking_task(ctx3, 30ms));
+    future_set.push_back(blocking_task(ctx4, 40ms));
+    future_set.push_back(blocking_task(ctx5, 50ms));
+    std::vector<async::context*> unblocked_contexts;
+    std::mutex unblocked_mutex;
+
+    // Exercise
+    async::run_until_done(
+      clk,
+      [&clk](auto p_wake_time) {
+        if (clk.now() > p_wake_time) {
+          return;
+        }
+        std::println("Sleeping for {}", p_wake_time - clk.now());
+        std::this_thread::sleep_until(p_wake_time);
+      },
+      async::unblock_listener::from([&](async::context& p_ctx) noexcept {
+        if (p_ctx.state() == async::blocked_by::io) {
+          std::lock_guard lock(unblocked_mutex);
+          unblocked_contexts.push_back(&p_ctx);
+        }
+      }),
+      // List of tasks
+      ctx0,
+      ctx1,
+      ctx2,
+      ctx3,
+      ctx4,
+      ctx5);
+
+    // Verify
+    expect(future_set[0].done()) << "Context 0 didn't finish!";
+    expect(future_set[1].done()) << "Context 1 didn't finish!";
+    expect(future_set[2].done()) << "Context 2 didn't finish!";
+    expect(future_set[3].done()) << "Context 3 didn't finish!";
+    expect(future_set[4].done()) << "Context 4 didn't finish!";
+    expect(future_set[5].done()) << "Context 5 didn't finish!";
+
+    expect(that % 1 == std::ranges::count(unblocked_contexts, &ctx0));
+    expect(that % 1 == std::ranges::count(unblocked_contexts, &ctx1));
+    expect(that % 1 == std::ranges::count(unblocked_contexts, &ctx2));
+    expect(that % 1 == std::ranges::count(unblocked_contexts, &ctx3));
+    expect(that % 1 == std::ranges::count(unblocked_contexts, &ctx4));
+    expect(that % 1 == std::ranges::count(unblocked_contexts, &ctx5));
+  };
+}
+
+int main()
+{
+  run_sleep_task_test();
+}

--- a/tests/simple_scheduler.test.cpp
+++ b/tests/simple_scheduler.test.cpp
@@ -48,7 +48,6 @@ async::future<void> sensor_pipeline(async::context& ctx,
   int sensor_value = co_await read_sensor(ctx, p_name);
   int processed = co_await process_data(ctx, p_name, sensor_value);
   co_await write_actuator(ctx, p_name, processed);
-
 }
 
 // Type-erased future wrapper for storing different future types


### PR DESCRIPTION
## Summary

Adds a new `async_context.schedulers` module providing a cooperative scheduling loop (`run_until_done`) and supporting clock infrastructure. This separates scheduling policy from the core coroutine machinery, keeping `async_context` lean while giving users a ready-made, heap-free scheduler for both hosted and bare-metal targets.

## Related Issue

Closes #81 

## Changes

- **New module `async_context.schedulers`** — separates scheduling from core; exports `async::clock` concept, `async::chrono_clock_adapter`, `async::context_derived` concept, and `async::run_until_done`
- **`async::clock` concept** — instance-based (not static), designed for hardware clock injection on bare-metal; any `std::chrono` clock can be adapted via `chrono_clock_adapter`
- **`async::chrono_clock_adapter<ChronoClock>`** — zero-size adapter wrapping `std::chrono` clocks into `async::clock`; always optimized away by the compiler
- **`async::run_until_done`** — stack-allocated cooperative scheduler loop; drives a variadic set of contexts to completion with a user-supplied `sleep_until` callable; RAII guarantees all unblock listener registrations are cleared before the function returns, even on exception
- **Interruptable sleep overload** — second overload of `run_until_done` accepts an `async::unblock_listener` so an ISR or I/O completion can wake the sleep primitive early
- **`test_package` rewrite** — updated to demonstrate `run_until_done` with two concurrent sensor pipelines; fixed stack-use-after-scope bug caused by an immediately-invoked lambda whose closure was accessed after it was destroyed
- **New tests** — `run_until_done.test.cpp` and `clock_adapter.test.cpp` covering scheduling correctness, time-based blocking, I/O unblocking, and the clock adapter
- **README** — added documentation for `async::clock`, `chrono_clock_adapter`, and `run_until_done` with usage examples; updated first example to use `run_until_done`

## Test Plan

- [x] All CI checks pass
- [x] New/updated tests cover the changes
- [x] Tested locally with `conan create .`
- [x] ASan clean on `test_package` and `test_run_until_done`
