### PR TITLE
:fire: (patch) Remove conan-level enable_clang_tidy/clang_tidy_fix options

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,12 @@
-Checks: "readability-identifier-naming,modernize-*,performance-*,bugprone-*,-modernize-use-trailing-return-type,-bugprone-exception-escape"
-HeaderFilterRegex: ".*"
+Checks: >
+  -*,
+  readability-identifier-naming,
+  modernize-*,
+  performance-*,
+  bugprone-*,
+  -bugprone-exception-escape,
+  clang-diagnostic-dangling*,
+  -modernize-use-trailing-return-type
 WarningsAsErrors: "*"
 UseColor: true
 CheckOptions:

--- a/conanfile.py
+++ b/conanfile.py
@@ -37,14 +37,6 @@ class async_context_conan(ConanFile):
     exports_sources = "modules/*", "benchmarks/*", "tests/*", "CMakeLists.txt", "LICENSE", ".clang-tidy"
     package_type = "static-library"
     shared = False
-    options = {
-        "enable_clang_tidy": [True, False],
-        "clang_tidy_fix": [True, False],
-    }
-    default_options = {
-        "enable_clang_tidy": False,
-        "clang_tidy_fix": False,
-    }
 
     @property
     def _min_cppstd(self):
@@ -100,7 +92,7 @@ class async_context_conan(ConanFile):
     def build_requirements(self):
         self.tool_requires("cmake/[^4.0.0]")
         self.tool_requires("ninja/[^1.3.0]")
-        self.requires("libhal-cmake-util/[^5.0.6]")
+        self.requires("libhal-cmake-util/[^5.0.9]")
         if str(self.settings.os) != "baremetal":
             self.test_requires("boost-ext-ut/2.3.1",
                                options={'disable_module': False})
@@ -121,8 +113,6 @@ class async_context_conan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.generator = "Ninja"
-        tc.variables["LIBHAL_ENABLE_CLANG_TIDY"] = self.options.enable_clang_tidy
-        tc.variables["LIBHAL_CLANG_TIDY_FIX"] = self.options.clang_tidy_fix
         tc.generate()
 
         deps = CMakeDeps(self)


### PR DESCRIPTION
Clang-tidy is now controlled directly by LibhalClangTidy.cmake (enabled by default), so there's no need to thread a duplicate conan option through every consumer's conanfile.py just to forward it into the cmake cache.